### PR TITLE
V0.5.0 - add secondary log support

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -150,11 +150,7 @@ module ActFluentLoggerRails
       end
 
       @fluent_logger.post(@tag, @map)
-
-      if @secondary_log
-        @secondary_log.add(@severity, @map)
-        @secondary_log.flush
-      end
+      @secondary_log.add(@severity, @map) if @secondary_log
 
       @severity = 0
       @messages.clear


### PR DESCRIPTION
Cherry-pick out the commits that were being used in the `add_secondary_log_support` branch. This specific branch is used within https://github.com/mavenlink/mobile repo. In order to bump the version of Rails there, we need be on a higher version of `act-fluent-logger-rails`.